### PR TITLE
Added device discovery

### DIFF
--- a/dd.go
+++ b/dd.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"io"
-	"os/exec"
 	"strconv"
 	"strings"
 )
@@ -58,47 +57,6 @@ func CopyConvert(iff string, of string) (chan DdProgress, error) {
 		}
 	})()
 	return channel, nil
-}
-
-// Device is a struct representing a block device.
-type Device struct {
-	Name  string
-	Model string
-	Size  string
-}
-
-// GetDevices returns the list of USB devices available to read/write from.
-func GetDevices() ([]Device, error) {
-	// TODO: Complete GetDevices properly.
-	res, err := exec.Command("lsblk", "-o", "KNAME,TYPE,SIZE,MODEL").Output()
-
-	if err != nil {
-		return nil, err
-	}
-
-	files := strings.Split(string(res), "\n")
-	files = files[:len(files)-1]
-
-	disks := []Device{}
-
-	for _, file := range files {
-		disk := strings.Fields(file)
-		if disk[1] == "disk" && !strings.HasPrefix(disk[0], "zram") {
-
-			device := Device{
-				Name: "/dev/" + disk[0],
-				Size: disk[2],
-			}
-
-			if !(len(disk) < 4 || disk[3] == "") {
-				device.Model = disk[3]
-			}
-
-			disks = append(disks, device)
-		}
-	}
-
-	return disks, nil
 }
 
 // dropCR drops a terminal \r from the data.

--- a/devices.go
+++ b/devices.go
@@ -19,6 +19,15 @@ func GetDevices() ([]Device, error) {
 		return nil, err
 	}
 
+	bootDevices, err := exec.Command("df", "/", "/home").Output()
+	if err != nil {
+		return nil, err
+	}
+
+	splitBoot := strings.Split(string(bootDevices), "\n")
+	rootPart := splitBoot[1]
+	homePart := splitBoot[2]
+
 	files := strings.Split(string(res), "\n")
 	files = files[:len(files)-1]
 
@@ -26,7 +35,9 @@ func GetDevices() ([]Device, error) {
 
 	for _, file := range files {
 		disk := strings.Fields(file)
-		if disk[1] == "disk" && !strings.HasPrefix(disk[0], "zram") {
+		if disk[1] == "disk" && !strings.HasPrefix(disk[0], "zram") &&
+			!strings.HasPrefix(rootPart, "/dev/"+disk[0]) &&
+			!strings.HasPrefix(homePart, "/dev/"+disk[0]) {
 			device := Device{
 				Name: "/dev/" + disk[0],
 				Size: disk[2],

--- a/devices.go
+++ b/devices.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"os/exec"
+	"strings"
+)
+
+// Device is a struct representing a block device.
+type Device struct {
+	Name  string
+	Model string
+	Size  string
+}
+
+// GetDevices returns the list of USB devices available to read/write from.
+func GetDevices() ([]Device, error) {
+	res, err := exec.Command("lsblk", "-o", "KNAME,TYPE,SIZE,MODEL").Output()
+	if err != nil {
+		return nil, err
+	}
+
+	files := strings.Split(string(res), "\n")
+	files = files[:len(files)-1]
+
+	disks := []Device{}
+
+	for _, file := range files {
+		disk := strings.Fields(file)
+		if disk[1] == "disk" && !strings.HasPrefix(disk[0], "zram") {
+			device := Device{
+				Name: "/dev/" + disk[0],
+				Size: disk[2],
+			}
+
+			if len(disk) >= 4 && disk[3] != "" {
+				device.Model = disk[3]
+			}
+
+			disks = append(disks, device)
+		}
+	}
+
+	return disks, nil
+}

--- a/main.go
+++ b/main.go
@@ -60,14 +60,22 @@ func main() {
 
 	// Bind a function to request refresh of devices attached.
 	w.Bind("refreshDevices", func() {
-		devices := GetDevices()
+		devices, err := GetDevices()
+		if err != nil {
+			w.Eval("setDialogReact(" + ParseToJsString("Error: "+err.Error()) + ")")
+			return
+		}
 		jsonifiedDevices := make([]string, len(devices))
 		for index, device := range devices {
-			jsonifiedDevices[index] = ParseToJsString(device)
+			if device.Model == "" {
+				jsonifiedDevices[index] = ParseToJsString(device.Name + " (" + device.Size + ")")
+			} else {
+				jsonifiedDevices[index] = ParseToJsString(device.Name + " (" + device.Model + ", " + device.Size + ")")
+			}
 		}
 		// Call setDevicesReact.
 		w.Eval("setDevicesReact([" + strings.Join(jsonifiedDevices, ", ") + "])")
-		w.Eval("setSelectedDeviceReact(" + ParseToJsString(devices[0]) + ")")
+		w.Eval("setSelectedDeviceReact(" + jsonifiedDevices[0] + ")")
 	})
 
 	// Bind a function to prompt for file.

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ const App = () => {
   window.setSelectedDeviceReact = setSelectedDevice
 
   const onFlashButtonClick = () => {
-    if (selectedDevice && selectedDevice !== 'N/A') window.flash(file, selectedDevice)
+    if (selectedDevice && selectedDevice !== 'N/A') window.flash(file, selectedDevice.split(' ')[0])
     else setDialog('Error: Select a device to flash the ISO to!')
   }
   const onFileInputChange = (event) => setFile(event.target.value.replace(/\n/g, ''))


### PR DESCRIPTION
- Added a `Device` struct with Name/Model/Size.
- GetDevices now returns a slice of `Device`s and error.
- Uses `lsblk` to get the information.
- Excluded `zram` devices.

TODO: Supporting macOS, LVM and RAID.